### PR TITLE
fix(abort): abort was setting Exception.args instead of `sol` attribute

### DIFF
--- a/schedula/utils/dsp.py
+++ b/schedula/utils/dsp.py
@@ -1047,7 +1047,7 @@ class SubDispatchPipe(SubDispatchFunction):
             s = key_map[s]
 
             if s.stopper.is_set():
-                raise DispatcherAbort(sol, "Stop requested.")
+                raise DispatcherAbort("Stop requested.", sol=sol)
 
             has_node = v not in s.workflow.node
             if has_node or not s._set_node_output(v, False, next_nds=nxt_nds):

--- a/schedula/utils/sol.py
+++ b/schedula/utils/sol.py
@@ -218,7 +218,7 @@ class Solution(Base, collections.OrderedDict):
             n = (d, _, (v, sol)) = heapq.heappop(fringe)
 
             if sol.stopper.is_set():
-                raise DispatcherAbort(self, "Stop requested.")
+                raise DispatcherAbort("Stop requested.", sol=self)
 
             # Skip terminated sub-dispatcher or visited nodes.
             if sol.index in dsp_closed or (v is not START and v in sol.dist):


### PR DESCRIPTION
+ Sideffect was that str(ex) was too big and it included the solution (eg co2mpas GUI).
+ 2 irrelevant(?) TCs fail: `Directive.test_build` & `Draw.test_view`.