### PR TITLE
update to canonical pypi name of beautifulsoup4

### DIFF
--- a/requirements/plot.pip
+++ b/requirements/plot.pip
@@ -5,6 +5,6 @@ regex
 graphviz
 Pygments
 lxml
-bs4
+beautifulsoup4
 jinja2
 docutils

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ if __name__ == '__main__':
 
     extras = {
         'web': ['regex', 'flask'],
-        'plot': ['graphviz', 'regex', 'flask', 'Pygments', 'lxml', 'bs4',
+        'plot': ['graphviz', 'regex', 'flask', 'Pygments', 'lxml', 'beautifulsoup4',
                  'jinja2', 'docutils'],
         'parallel': ['multiprocess'],
     }


### PR DESCRIPTION
Thanks for `schedula`! I'm working on packaging it (and `formulas`) for conda-forge, and am bumping into various issues. 

This one was pretty easy. [PyPI says](https://pypi.org/project/bs4/):
> This is a dummy package managed by the developer of Beautiful Soup to prevent name squatting. The official name of PyPI’s Beautiful Soup Python package is beautifulsoup4. This package ensures that if you type pip install bs4 by mistake you will end up with Beautiful Soup.

Hopefully nothing else to report, but I'll be attempting to reproduce the full build chain (and with the install-time dependency on the sphinx stack to get long_description, it is indeed pretty full, and can't be done from the `sdist`) so who knows what else i'll find!