### PR TITLE
fix(jinja) Enable HTML AutoEscape

### DIFF
--- a/schedula/ext/autosummary.py
+++ b/schedula/ext/autosummary.py
@@ -82,7 +82,7 @@ def generate_autosummary_docs(
         if template_dir:
             template_dirs.insert(0, template_dir)
         template_loader = FileSystemLoader(template_dirs)
-    template_env = SandboxedEnvironment(loader=template_loader)
+    template_env = SandboxedEnvironment(loader=template_loader, autoescape=True)
 
     # read
     items = find_autosummary_in_files(sources)

--- a/schedula/utils/drw/__init__.py
+++ b/schedula/utils/drw/__init__.py
@@ -116,7 +116,7 @@ def autoplot_callback(res):
 
 
 def jinja2_format(source, context=None, **kw):
-    return Environment(**kw).from_string(source).render(context or {})
+    return Environment(**kw, autoescape=True).from_string(source).render(context or {})
 
 
 def valid_filename(item, filenames, ext=None):


### PR DESCRIPTION
## Status
**READY**

## Description
Disable HTML AutoEscape in Jinja template

## Related Issues
List related Issues against other branches:

Issue | Description
----- | ------------
[schedula issue #21](https://github.com/vinci1it2000/schedula/issues/21) | Jinja templates should use autoescape=True to reduce risk of template injection

## Todos
- [n/a] Tests
- [n/a] Documentation

## Steps to Test or Reproduce
None currently available

