### PR TITLE
fix(gen): Replace itertools.count with a picklable counter to support Python 3.14.

### DIFF
--- a/schedula/utils/gen.py
+++ b/schedula/utils/gen.py
@@ -13,9 +13,17 @@ These are python-specific utilities and hacks - general data-processing or
 numerical operations.
 """
 
-import itertools
-
 __author__ = 'Vincenzo Arcidiacono <vinci1it2000@gmail.com>'
+
+
+class _Counter:
+    def __init__(self, start=0, step=1):
+        self.value, self.step = start, step
+
+    def __call__(self):
+        value = self.value
+        self.value += self.step
+        return value
 
 
 def counter(start=0, step=1):
@@ -30,7 +38,7 @@ def counter(start=0, step=1):
         Step value.
     :type step: int, float, optional
     """
-    return itertools.count(start, step).__next__
+    return _Counter(start, step)
 
 
 class _Token:

--- a/tests/utils/test_gen.py
+++ b/tests/utils/test_gen.py
@@ -7,6 +7,7 @@
 # You may obtain a copy of the Licence at: http://ec.europa.eu/idabc/eupl
 
 import os
+import pickle
 import unittest
 import schedula as sh
 from copy import copy, deepcopy
@@ -42,3 +43,29 @@ class TestUtils(unittest.TestCase):
 
         b = a
         self.assertEqual({a: 1, 1: 3}, {b: 1, 1: 3})
+
+    def test_counter(self):
+        c = sh.counter()
+        self.assertEqual([c(), c(), c()], [0, 1, 2])
+
+        c = sh.counter(10, 5)
+        self.assertEqual([c(), c(), c()], [10, 15, 20])
+
+    def test_counter_serialization(self):
+        c = sh.counter()
+        for _ in range(48):
+            c()
+
+        # The counter is stateful: a round-trip that restarted from `start`
+        # would make a restored dispatcher reuse already assigned node indices.
+        self.assertEqual(pickle.loads(pickle.dumps(c))(), 48)
+        self.assertEqual(copy(c)(), 48)
+        self.assertEqual(deepcopy(c)(), 48)
+        self.assertEqual(c(), 48)
+
+    def test_dispatcher_copy_preserves_counter(self):
+        dsp = sh.Dispatcher()
+        dsp.add_data('a')
+        i = dsp.counter()
+        self.assertEqual(dsp.copy().counter(), i + 1)
+        self.assertEqual(deepcopy(dsp).counter(), i + 1)


### PR DESCRIPTION
## Status
**READY**

## Description

Python 3.14 [removed pickle, copy and deepcopy support from `itertools`
objects](https://docs.python.org/3.14/whatsnew/3.14.html#itertools) (deprecated
since 3.12, [gh-101588](https://github.com/python/cpython/issues/101588)).

`counter()` returns `itertools.count(start, step).__next__`, a method-wrapper
whose `__self__` *is* the `itertools.count`. Every `Dispatcher` stores one in
`self.counter`, and `Dispatcher.__getstate__` keeps it in the pickled state, so
on 3.14 any attempt to serialise or deep-copy a dispatcher fails with:

```
TypeError: cannot pickle 'itertools.count' object
```

This is a regression against 3.13, where the same calls succeed (and emit
`DeprecationWarning: Pickle, copy, and deepcopy support will be removed from
itertools in Python 3.14`):

| Python | `dsp.copy()` | `copy.deepcopy(dsp)` | `dill.dumps(dsp)` |
|---|---|---|---|
| 3.13.12 | OK | OK | OK |
| 3.14.5 (before) | `TypeError` | `TypeError` | `TypeError` |
| 3.14.5 (after) | OK | OK | OK |

So this is not only a serialisation concern — `Dispatcher.copy()`, a documented
public method, is currently broken on 3.14.

### The fix

`itertools.count` is created in exactly one place in the codebase (a single grep
hit, `schedula/utils/gen.py`), so that one function is the whole 3.14 blocker.
It is replaced with a small picklable callable:

```python
class _Counter:
    def __init__(self, start=0, step=1):
        self.value, self.step = start, step

    def __call__(self):
        value = self.value
        self.value += self.step
        return value
```

Notes on compatibility:

- `counter`'s **name, signature and docstring are unchanged** — it stays a public
  lazy export of `schedula`, and the existing docstring ("Return a object whose
  `.__call__()` method returns consecutive values") already describes exactly
  this. The change is internal to the returned object.
- Every call site only *calls* the returned object; there is no
  `__self__`/method-wrapper introspection anywhere in the codebase.
- `SiteNode`, `FolderNode` and `SiteFolder` hold a counter as a **class
  attribute** and call it as `self.counter()`. This keeps working because the
  replacement, like the method-wrapper it replaces, is not a descriptor — so it
  is never bound to the instance. Verified explicitly (`hasattr(type(counter()),
  '__get__')` is `False` both before and after), and `SiteNode.counter is
  SiteFolder.counter` still holds.
- The round-trip preserves the counter's **current position**, not just
  `start`/`step`. That matters: a counter that restarted from `start` after
  deserialisation would hand out node indices that were already assigned.
- `import itertools` is dropped from `gen.py` as it had no other use.

### Trade-off worth stating

`itertools.count.__next__` advances atomically under the GIL; the Python-level
`+=` above does not. The counters are used on graph-construction and plot-id
paths rather than the concurrent dispatch path, so in practice this should not
be reachable, but it is a real difference and I would rather flag it than hide
it. If you would prefer it airtight, an `itertools.count` guarded by a
`threading.Lock` — or a `__reduce__` on the class — would both work; happy to
switch to whichever you prefer.

### Alternative considered and rejected

Registering a `copyreg.pickle(itertools.count, ...)` reducer that recovers
`(start, step)` from `repr(count)`. It does round-trip faithfully, but it
patches pickling for *every* `itertools.count` in the process (not just
schedula's) and relies on parsing a repr, so it seemed clearly worse than
fixing the single creation site.

## Related Issues

Issue | Description
----- | ------------
[python/cpython#101588](https://github.com/python/cpython/issues/101588) | Deprecate (3.12) then remove (3.14) pickle/copy/deepcopy support in `itertools`

## Todos
- [x] Tests
- [ ] Documentation — none needed, the public docstring is unchanged

## Steps to Test or Reproduce

Before the patch, on Python 3.14:

```sh
python -c "
import copy, schedula
d = schedula.Dispatcher(); d.add_data('a')
d.copy()
"
# TypeError: cannot pickle 'itertools.count' object
```

After the patch, the new cases in `tests/utils/test_gen.py` cover it:

```sh
git checkout fix/counter-picklable-py314
python -m unittest tests.utils.test_gen -v
```

`test_counter_serialization` and `test_dispatcher_copy_preserves_counter` both
fail on 3.14 without the `gen.py` change and pass with it. `test_counter` covers
the plain `start`/`step` behaviour.

### What I ran

- `tests/utils/test_gen.py` — 5 tests, green on 3.14.5 **and** 3.13.12.
- `tests/utils/{test_dsp,test_base,test_blue,test_alg,test_gen,test_des}.py` —
  32 tests, green on 3.14.5 and 3.13.12 (with the optional extras installed).
- `tests/test_dispatcher.py` — 49 tests on 3.14.5, 48 pass. See the note below
  about the one failure.
- An end-to-end check with a downstream library that compiles a dispatcher and
  serialises it with `dill`: before the patch `dill.dumps` raises
  `cannot pickle 'itertools.count' object`; after it, the round-trip succeeds,
  the counter comes back at the same position, and the restored model still
  computes the right result.

## Separate 3.14 issue, not addressed here

`tests.test_dispatcher.TestDispatch.test_raises` fails on 3.14 **both with and
without this patch** — CPython changed the `math.log` domain error message:

```
3.13: ValueError('math domain error')
3.14: ValueError('expected a positive input')
```

and the test compares the message verbatim. It is unrelated to the counter, so I
left it alone rather than widen this PR.

That is also why I did not add `3.14` to the CI matrix or to the classifiers in
`setup.py` (which currently stop at 3.13) — a 3.14 job would go red on the above
until that assertion is relaxed. If you would like it, I am happy to fix
`test_raises` and add 3.14 to `.github/workflows/*.yml` and the classifiers,
either in this PR or a follow-up — just say which you prefer.
